### PR TITLE
remove background from Card component

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -16,7 +16,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
       ref={ref}
       data-testid="card"
       className={cn(
-        'w-full h-fit bg-secondary text-f-primary rounded-sm',
+        'w-full h-fit text-f-primary rounded-sm',
         borderClass,
         className,
       )}


### PR DESCRIPTION
We are removing the `bg-secondary` **className** from `Card` component.